### PR TITLE
Latlon gps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # parsegonio v0.1.1
 * added a similar function named `parsegonio_favorite_messages` to parse messages that were exported using the save messages option for a favorited platform.
+* user adjustable lon and lat (still one per prv file though)
 
 # parsegono v0.1.0
 * initial release for testing

--- a/README.md
+++ b/README.md
@@ -50,11 +50,7 @@ cat(output, file = "gonio_output.prv")
 - `pttkey_file` is a `csv` which includes the PTT, hex, and DeployID of platforms of interest (only the PTT and hex are necessary)
 - `gfile`, in this case an example Goniometer log included in this repo.
 
-I’ve saved the output to `gonio_output.prv` here. It seems like there is some flexibility in the `prv` format and I’ve taken some liberties, mainly because I don’t entirely understand every part of the format. In my simulated `prv`, for each platform, all the messages from the Goniometer log are lumped under one satellite pass even if they occurred over many days. This isn’t realistic, but DAP Processor doesn’t seem to mind and satellite passes don’t mean anything in this use case anyway. In addition, real `prv` files include the Doppler Argos position. Obviously I don’t have one, so I just added a point near our field site. This is hardcoded (sorry) and so you might want to change it to something nearer your field site especially if you want to decode `FastGPS` positions (See issue [#4](https://github.com/williamcioffi/parsegonio/issues/4)). Edit line 11 of `parsegonio.R` to change the simulated Argos position.
-
-```r
-h6 <- " 34.716  283.328  0.000 401677432"
-```
+I’ve saved the output to `gonio_output.prv` here. It seems like there is some flexibility in the `prv` format and I’ve taken some liberties, mainly because I don’t entirely understand every part of the format. In my simulated `prv`, for each platform, all the messages from the Goniometer log are lumped under one satellite pass even if they occurred over many days. This isn’t realistic, but DAP Processor doesn’t seem to mind and satellite passes don’t mean anything in this use case anyway. In addition, real `prv` files include the Doppler Argos position. Obviously I don’t have one, so I just added a point near our field site. You can change add your own positions as strings with three decimal placers using the parameters `lon` and `lat`. The format appears to be 0-360 instead of -180 to +180 by the way. There is some more chitchat about all of this in [issue #4](https://github.com/williamcioffi/parsegonio/issues/4).
 
 Once you have the simulated prv output you can just drag it into DAP processor. It helps to have preloaded a workspace with wch files as well as DAP will use the tag settings during decoding, though you can still get something even without them.
 
@@ -73,7 +69,7 @@ The best solution is don’t use excel because it is a terrible `csv` editor. Bu
 ![](docs/images/savedhex.png)
 
 ## Creating a prv from the exported messages of a favorite platform
-I've included an example file `favorite_ptt_180754.xls` obtained by using the save messages option for a favorited platform. To create a `prv` file, first simply save it as a csv. The expected date format is `%d-%m-%y %H:%M:%S`. If you need to change it for some reason the crucial line is 186 in `parsegonio.r`. Then you can simply run something like and decode the prv as explained above.
+I've included an example file `favorite_ptt_180754.xls` obtained by using the save messages option for a favorited platform. To create a `prv` file, first simply save it as a csv. The expected date format is `%d-%m-%y %H:%M:%S` (this is currently hardcoded around line 186 if you have to change it). After saving a csv file you can simply run something like this and decode the prv as explained above:
 
 ```r
 gfile <- "favorite_ptt_180754.csv"

--- a/parsegonio.R
+++ b/parsegonio.R
@@ -1,6 +1,6 @@
 # parse the raw goniometer files
 
-parsegonio <- function(gfile, pttkey_file, prv_output = TRUE) {
+parsegonio <- function(gfile, pttkey_file, prv_output = TRUE, lon = '283.328', lat = '34.716') {
 # constants for the fake prv file
 # header
 h1 <- "03126"
@@ -8,7 +8,7 @@ h2 <- ""	# this is the ptt
 h3 <- " 75 31 A 2"
 h4 <- ""	# this is the date
 h5 <- ""    # this is the time
-h6 <- " 34.716  283.328  0.000 401677432"
+h6 <- paste0(" ", lat, "  ", lon, "  0.000 401677432")
 
 # footer
 f1 <- "" 	# this is the number of messages
@@ -107,7 +107,7 @@ desehex <- pttkey$HEX[which(pttkey$DEPLOYID != "")]
 # look for just those hex codes
 subg <- allg[which(allg$V9 %in% desehex), ]
 
-if(dsa_output) {
+if(prv_output) {
   # set up vectors to make dsa
   foundhexes <- unique(subg$V9)
   foundptts <- pttkey$PTT[match(foundhexes, pttkey$HEX)]
@@ -170,7 +170,7 @@ output
 
 # use this one for a csv saved from the .xls output
 # favorited messages
-parsegonio_favorite_messages <- function(gfile, ptt) {
+parsegonio_favorite_messages <- function(gfile, ptt, lon = '283.328', lat = '34.716') {
 # constants for the fake prv file
 # header
 h1 <- "03126"
@@ -178,7 +178,7 @@ h2 <- ""	# this is the ptt
 h3 <- " 75 31 A 2"
 h4 <- ""	# this is the date
 h5 <- ""    # this is the time
-h6 <- " 34.716  283.328  0.000 401677432"
+h6 <- paste0(" ", lat, "  ", lon, "  0.000 401677432")
 
 g <- read.table(gfile, sep = ',', header = TRUE, stringsAsFactors = FALSE)
 


### PR DESCRIPTION
adds parameters `lon` and `lat` mainly to assist with fastloc decoding down the line. the idea is to set them to the neighborhood. still only set one per prv output. I'm going to leave issue #4 open for now, because this isn't well tested and I don't know what all the ramifications are.